### PR TITLE
Set propagate_at_launch to 1 vs true

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ data "null_data_source" "tags_as_list_of_maps" {
   inputs = {
     "key"                 = element(keys(var.tags), count.index)
     "value"               = element(values(var.tags), count.index)
-    "propagate_at_launch" = true
+    "propagate_at_launch" = 1
   }
 }
 
@@ -161,4 +161,3 @@ resource "aws_autoscaling_group" "default" {
     create_before_destroy = true
   }
 }
-


### PR DESCRIPTION
In my testing, this wanted to change a bunch of tags with
propagate_at_launch=1 to "true". This change fixes that behavior.